### PR TITLE
feat: expose multi-variant typed methods via Facade (v2.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ TOGUL_RETRY_COUNT=2
 
 ## Usage
 
+### Boolean flag (on/off)
+
 Via facade:
 
 ```php
@@ -54,7 +56,53 @@ Route::get('/dashboard', DashboardController::class)
     ->middleware('togul:new-dashboard');
 ```
 
+### Multi-variant flags
+
+Use typed facade methods to read flag values beyond boolean:
+
+```php
+use Togul\Laravel\Facades\Togul;
+
+$context = ['user_id' => (string) auth()->id()];
+
+// String variant
+$theme = Togul::evaluateString('ui-theme', $context, fallback: 'default');
+
+// Number variant
+$limit = Togul::evaluateNumber('rate-limit', $context, fallback: 100.0);
+
+// Boolean variant
+$flag = Togul::evaluateBool('beta-feature', $context, fallback: false);
+
+// JSON variant
+$config = Togul::evaluateJSON('feature-config', $context, fallback: null);
+```
+
+### Full evaluation result
+
+```php
+$result = Togul::evaluateResult('checkout-flow', $context);
+
+$result->enabled;              // bool
+$result->flagKey;              // string
+$result->valueType;            // 'boolean' | 'string' | 'number' | 'json'
+$result->reason;               // string
+
+$result->boolValue(false);
+$result->stringValue('');
+$result->numberValue(0.0);
+$result->jsonValue(null);
+```
+
+### Cache invalidation
+
+```php
+Togul::invalidateFlag('new-dashboard'); // single flag
+Togul::invalidateCache();               // all flags
+```
+
 ## Notes
 
 - `TOGUL_API_KEY` must be an environment API key, not a user JWT.
 - This package wraps `togul/php-sdk`; evaluation behavior follows the PHP SDK.
+- Typed accessors return the fallback if the flag is disabled or the value type does not match.

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,6 @@
             }
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "version": "2.4.0"
 }


### PR DESCRIPTION
## Summary

- Expose `evaluateResult`, `evaluateBool`, `evaluateString`, `evaluateNumber`, `evaluateJSON`, `invalidateFlag` on the `Togul` Facade via `@method static` doc-blocks
- Update README with multi-variant flag usage examples (facade, typed methods, full result, cache invalidation)
- Bump version to `2.4.0` — aligned with `togul/php-sdk` v2.4.0

## Test plan

- [ ] `Togul::isEnabled()` still works (backwards compatible)
- [ ] `Togul::evaluateString/Bool/Number/JSON()` resolve correctly via facade proxy
- [ ] IDE type hints work for all new methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)